### PR TITLE
[New Protocol] WinRM

### DIFF
--- a/dementor/__init__.py
+++ b/dementor/__init__.py
@@ -18,5 +18,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = "1.0.0.dev2"
+__version__ = "1.0.0.dev3"
 __author__ = "MatrixEditor"

--- a/dementor/assets/Dementor.toml
+++ b/dementor/assets/Dementor.toml
@@ -100,6 +100,13 @@ LDAP = true
 
 QUIC = true
 
+# Enables the WinRM server on port 5985. This setting is a shortcut for defining
+# an extra HTTP server. Note that if a global of HTTP local certificate and key
+# are configured, another WinRM server on port 5986 will be created.
+# The default value is: true
+
+WinRM = true
+
 
 # =============================================================================
 # Globals
@@ -457,6 +464,19 @@ WPADAuthRequired = true
 
 [[HTTP.Server]]
 Port = 80
+
+# To build an HTTPS server, you need to enable TLS, and configure a certificate
+# [[HTTP.Server]]
+# Port = 443
+# TLS = true
+# Cert = "default.cert"
+# Key = "default.key"
+
+# To build a WinRM server, you just need to disable WPAD and WebDAV
+# [[HTTP.Server]]
+# Port = 5985
+# WPAD = false
+# WebDAV = false
 
 
 # =============================================================================

--- a/dementor/config.py
+++ b/dementor/config.py
@@ -41,10 +41,10 @@ class TomlConfig:
     _section_: str | None
     _fields_: list[Attribute]
 
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict | None = None) -> None:
         for field in self._fields_:
             self._set_field(
-                config,
+                config or {},
                 field.attr_name,
                 field.qname,
                 field.default_val,
@@ -152,6 +152,7 @@ class SessionConfig(TomlConfig):
         Attribute("mdns_enabled", "mDNS", True, factory=is_true),
         Attribute("http_enabled", "HTTP", True, factory=is_true),
         Attribute("msrpc_enabled", "RPC", True, factory=is_true),
+        Attribute("winrm_enabled", "WinRM", True, factory=is_true),
         Attribute("extra_modules", "ExtraModules", list),
         Attribute("workspace_path", "Workspace", DEMENTOR_PATH),
     ]
@@ -169,8 +170,8 @@ class SessionConfig(TomlConfig):
     def __init__(self) -> None:
         super().__init__(dm_config.get("Dementor", {}))
         # global options that are not loaded from configuration
-        self.ipv6: Optional[str] = None
-        self.ipv4: Optional[str] = None
+        self.ipv6 = None
+        self.ipv4 = None
         self.interface = None
         self.analysis = False
         self.loop = asyncio.get_event_loop()
@@ -189,6 +190,10 @@ class SessionConfig(TomlConfig):
     def is_bound_to_all(self) -> bool:
         # REVISIT: this should raise an exception
         return self.interface == "ALL"
+
+    @property
+    def bind_address(self) -> str:
+        return "::" if self.ipv6 else str(self.ipv4)
 
 
 def _read(path: str):

--- a/dementor/database.py
+++ b/dementor/database.py
@@ -197,11 +197,19 @@ class DementorDB:
         )
         results = self.db_exec(q).all()
         text = "Password" if credtype == _CLEARTEXT else "Hash"
+        username_text = markup.escape(username)
+        is_blank = len(str(username).strip()) == 0
+        if is_blank:
+            username_text = "(blank)"
+
         full_name = (
-            f"[b]{markup.escape(username)}[/]/[b]{markup.escape(domain)}[/]"
+            f" for [b]{username_text}[/]/[b]{markup.escape(domain)}[/]"
             if domain
-            else f"[b]{markup.escape(username)}[/]"
+            else f" for [b]{username_text}[/]"
         )
+        if is_blank:
+            full_name = ""
+
         if not results or self.config.db_config.db_duplicate_creds:
             # just insert a new row
             q = sql.insert(self.CredentialsTable).values(
@@ -219,13 +227,13 @@ class DementorDB:
             self.db_exec(q)
             with dm_console_lock:
                 target_logger.success(
-                    f"Captured {credtype} {text} for {full_name} from {client_address}:",
+                    f"Captured {credtype} {text}{full_name} from {client_address}:",
                     host=hostname or client_address,
                     locked=True,
                 )
                 if username != _NO_USER:
                     target_logger.highlight(
-                        f"{credtype} Username: {markup.escape(username)}",
+                        f"{credtype} Username: {username_text}",
                         host=hostname or client_address,
                         locked=True,
                     )

--- a/dementor/protocols/http.py
+++ b/dementor/protocols/http.py
@@ -20,7 +20,6 @@
 import socket
 import base64
 import pathlib
-from sre_constants import FAILURE
 import ssl
 
 from http import HTTPStatus
@@ -34,7 +33,7 @@ from jinja2 import select_autoescape
 from rich import markup
 from impacket import ntlm
 
-from dementor.config import Attribute as A, TomlConfig, get_value, is_true, dm_config
+from dementor.config import Attribute as A, TomlConfig, get_value, is_true
 from dementor.logger import ProtocolLogger, dm_logger
 from dementor.servers import ServerThread, bind_server
 from dementor.database import _CLEARTEXT, normalize_client_address, _NO_USER
@@ -266,6 +265,9 @@ class HTTPHandler(BaseHTTPRequestHandler):
         self.logger.debug(f"- - {msg}")
 
     def send_response(self, code: int, message: str | None = None) -> None:
+        if not hasattr(self, "_headers_buffer"):
+            self._headers_buffer = []
+
         super().send_response(code, message)
         for header in self.config.http_extra_headers:
             self._headers_buffer.append(f"{header}\r\n".encode("latin-1", "strict"))

--- a/dementor/protocols/quic.py
+++ b/dementor/protocols/quic.py
@@ -57,8 +57,7 @@ def apply_config(session):
 def create_server_threads(session):
     servers = []
     if session.quic_enabled:
-        address = "::" if session.ipv6 else session.ipv4 or ""
-        servers.append(QuicServerThread(session, address, ipv6=bool(session.ipv6)))
+        servers.append(QuicServerThread(session, session.bind_address, ipv6=bool(session.ipv6)))
 
     return servers
 

--- a/dementor/protocols/smb.py
+++ b/dementor/protocols/smb.py
@@ -148,13 +148,9 @@ class SMBServerThread(threading.Thread):
         # always disconnect
 
         # Change address_family to IPv6 if this is configured
-        address = self.config.ipv4
+        address = self.config.bind_address
         if self.config.ipv6:
             SMBSERVER.address_family = socket.AF_INET6
-            # empty string means all interfaces even though IPv6 can be bound to a specific
-            # interface. Unfortunately, impacket's SMBSERVER does not support binding to
-            # specific IPv6 addresses.
-            address = ""
 
         self.server = SMBSERVER(
             (address, self.server_config.smb_port),

--- a/dementor/protocols/smtp.py
+++ b/dementor/protocols/smtp.py
@@ -334,7 +334,7 @@ class SMTPServerThread(threading.Thread):
 
         # NOTE: hostname on the controller points to the local address that will be
         # bound and the SMTP hostname is just a string that will be sent to the client,
-        controller.hostname = "::" if self.config.ipv6 else self.config.ipv4
+        controller.hostname = config.bind_address
 
         # alter the server hostname
         controller.SMTP_kwargs["hostname"] = smtp_config.smtp_fqdn.split(".", 1)[0]

--- a/dementor/servers.py
+++ b/dementor/servers.py
@@ -136,7 +136,7 @@ class ThreadingUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
             self.address_family = socket.AF_INET6
 
         super().__init__(
-            server_address or ("", self.default_port),
+            server_address or (self.config.bind_address, self.default_port),
             RequestHandlerClass or self.default_handler_class,
         )
 
@@ -173,7 +173,7 @@ class ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         if config.ipv6 and not self.ipv4_only:
             self.address_family = socket.AF_INET6
         super().__init__(
-            server_address or ("", self.default_port),
+            server_address or (self.config.bind_address, self.default_port),
             RequestHandlerClass or self.default_handler_class,
         )
 

--- a/dementor/standalone.py
+++ b/dementor/standalone.py
@@ -259,7 +259,7 @@ def main_print_options(session: SessionConfig, interface):
     poisoners_lines.append(main_format_config("Interface", interface))
 
     protocols_lines = ["", "[bold]Servers:[/bold]"]
-    additional_protocols = ["KDC", "NBTDS"]
+    additional_protocols = ["KDC", "NBTDS", "WinRM"]
     for name in (list(session.protocols) or []) + additional_protocols:
         attr_name = f"{name.lower()}_enabled"
         value = getattr(session, attr_name, None)

--- a/docs/source/compat.rst
+++ b/docs/source/compat.rst
@@ -354,7 +354,7 @@ in development. The legend for each symbol is as follows:
         <tr>
             <td>WinRM</td>
             <td><i class="i-lucide checkfb sd-text-success l"></i></td>
-            <td><i class="i-lucide x sd-text-danger l"></i></td>
+            <td><i class="i-lucide checkfb sd-text-success l"></i></td>
         </tr>
         <tr>
             <td>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "Dementor"
 copyright = "2025-Present, MatrixEditor"
 author = "MatrixEditor"
-release = "1.0.0.dev2"
+release = "1.0.0.dev3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/config/http.rst
+++ b/docs/source/config/http.rst
@@ -155,6 +155,34 @@ Section ``[HTTP]``
         Sets the Fully Qualified Domain Name (FQDN) returned by the server. The hostname portion is
         used in NTLM responses. The domain portion is optional.
 
+    .. py:attribute:: Server.TLS
+        :type: bool
+        :value: false
+
+        *Linked to* :attr:`http.HTTPServerConfig.http_use_ssl`. *Can also be set in* ``[HTTP]``
+
+        Enables SSL/TLS support using a custom certificate.
+
+        .. versionadded:: 1.0.0.dev3
+
+    .. py:attribute:: Server.Cert
+        :type: str
+
+        *Linked to* :attr:`http.HTTPServerConfig.http_cert`. *Can also be set in* ``[HTTP]`` *or* ``[Globals]``
+
+        Specifies the path to the certificate used when TLS is enabled.
+
+        .. versionadded:: 1.0.0.dev3
+
+    .. py:attribute:: Server.Key
+        :type: str
+
+        *Linked to* :attr:`http.HTTPServerConfig.http_cert_key`. *Can also be set in* ``[HTTP]`` *or* ``[Globals]``
+
+        Specifies the private key file corresponding to the certificate used for TLS.
+
+        .. versionadded:: 1.0.0.dev3
+
 
 Default Configuration
 ---------------------

--- a/docs/source/config/main.rst
+++ b/docs/source/config/main.rst
@@ -108,3 +108,15 @@ attacks, but instead passively capture credentials:
     .. versionadded:: 1.0.0.dev2
 
     Enables or disables the DCE/RPC service. For more details, refer to :ref:`config_dcerpc`.
+
+
+.. py:attribute:: WinRM
+    :type: bool
+    :value: true
+
+    *Maps to* :attr:`config.SessionConfig.winrm_enabled`
+
+    .. versionadded:: 1.0.0.dev3
+
+    Enables or disables the WinRM service. For more details, refer to :ref:`config_winrm`.
+    Configuration is the same as described in :ref:`config_http`.

--- a/docs/source/config/protocols.rst
+++ b/docs/source/config/protocols.rst
@@ -7,15 +7,16 @@ Protocols
 .. toctree::
     :caption: Available Protocols
 
-    mdns
-    llmnr
-    netbios
-    ftp
-    kerberos
-    ntlm
-    smtp
-    smb
-    quic
-    ldap
-    http
     dcerpc
+    ftp
+    http
+    kerberos
+    ldap
+    llmnr
+    mdns
+    netbios
+    ntlm
+    quic
+    smb
+    smtp
+    winrm

--- a/docs/source/config/winrm.rst
+++ b/docs/source/config/winrm.rst
@@ -1,0 +1,40 @@
+.. _config_winrm:
+
+WinRM
+=====
+
+.. versionadded:: 1.0.0.dev3
+
+Since WinRM operates over HTTP, all configuration values from the :ref:`config_http` section also apply here.
+*WinRM* does not have its own dedicated section; instead, it inherits its configuration settings directly
+from the HTTP section.
+
+To configure a custom WinRM server, you can use the following example:
+
+.. code-block:: toml
+    :caption: Dementor.toml
+
+    [[HTTP.Server]]
+    Port = 5985
+    WebDAV = false
+    WPAD = false
+
+By default, the service listens on port ``5985``. It can be enabled easily via the :attr:`Dementor.WinRM` shortcut.
+
+If the HTTP configuration (or the ``[Globals]`` section) specifies a certificate and private key, an additional
+WinRM service over HTTPS will automatically start on port ``5986``. You can also configure it manually as shown below:
+
+.. code-block:: toml
+    :caption: Dementor.toml
+
+    [[HTTP.Server]]
+    Port = 5986
+    WebDAV = false
+    WPAD = false
+    TLS = true
+    Cert = "/path/to/certfile"
+    Key = "/path/to/keyfile"
+
+.. seealso::
+
+    See the :ref:`config_http` section for full details on HTTP service configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dementor"
-version = "1.0.0.dev2"
+version = "1.0.0.dev3"
 license = { file = "LICENSE" }
 
 description = "LLMNR/NBT-NS/mDNS Poisoner and rogue service provider"


### PR DESCRIPTION
## Support for WinRM

This feature request includes protocol support for WinRM (using existing HTTP service).

- [x] Documentation pages 
- [x] Basic implementation of common authentication schemes
- [x] Documentation of additional settings in Dementor.toml

## Other Fixes

+ HTTP logger is now applied correctly to all requests
+ HTTP service now supports HTTPS configuration (WinRM implicitly uses the configured certificate and key)
+ `SessionConfig` now stores the central bind address for all servers
+ Blank usernames will be displayed as `(blank)` 