### PR TITLE
[Protocol Update] SMB Rewrite

### DIFF
--- a/dementor/__init__.py
+++ b/dementor/__init__.py
@@ -18,5 +18,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = "1.0.0.dev7"
+__version__ = "1.0.0.dev8"
 __author__ = "MatrixEditor"

--- a/dementor/assets/Dementor.toml
+++ b/dementor/assets/Dementor.toml
@@ -232,19 +232,15 @@ AllowedQueryTypes = ["A", "AAAA", "ALL"]
 # The name that will be used to identify the SMB server when responding to client
 # queries.
 
-ServerName = "SPOOFED"
+# FQDN = "name.domain.com"
 
 # The operating system reported by the SMB server. This helps identify the type
 # of server responding.
 
 # ServerOS = "UNIX"
 
-# The domain that the SMB server is identified as. In many cases, this is "WORKGROUP"
-# for local setups.
-
-ServerDomain = "WORKGROUP"
-
-# Enables SMB2 protocol support.
+# Enables SMB2 protocol support. Requests made with SMB1 will be upgraded automatically
+# to SMB2.
 
 SMB2Support = true
 

--- a/dementor/config/util.py
+++ b/dementor/config/util.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 import random
 import string
+import secrets
 
 from typing import Any
 from jinja2.sandbox import SandboxedEnvironment
@@ -48,6 +49,28 @@ def get_value(section: str, key: str | None, default=None) -> Any:
 # --- factory methods for attributes ---
 def is_true(value: str) -> bool:
     return str(value).lower() in ("true", "1", "on", "yes")
+
+
+class BytesValue:
+    def __init__(self, length=None) -> None:
+        self.length = length
+
+    def __call__(self, value) -> Any:
+        match value:
+            case None:
+                return secrets.token_bytes(self.length or 1)
+
+            case str():
+                try:
+                    return bytes.fromhex(value)
+                except ValueError:
+                    return value.encode()
+
+            case bytes():
+                return value
+
+            case _:
+                return str(value).encode()
 
 
 def random_value(size: int) -> str:

--- a/dementor/protocols/imap.py
+++ b/dementor/protocols/imap.py
@@ -133,7 +133,7 @@ class IMAPHandler(BaseProtoHandler):
         self._write_line(line)
 
     def _write_line(self, msg: str) -> None:
-        self.logger.debug(f"(imap) S: {msg!r}")
+        self.logger.debug(repr(msg), is_server=True)
         self.send(f"{msg}\r\n".encode("utf-8", "strict"))
 
     #  There are three possible server completion responses:
@@ -183,7 +183,7 @@ class IMAPHandler(BaseProtoHandler):
         # If the client wishes to cancel an authentication exchange, it issues a line consisting
         # of a single "*"
         resp = self.rfile.readline(1024).strip()
-        self.logger.debug(f"(imap) C: {resp!r}")
+        self.logger.debug(repr(resp), is_client=True)
         if resp == b"*":
             self.bad("Authentication canceled")
             raise StopHandler
@@ -220,7 +220,7 @@ class IMAPHandler(BaseProtoHandler):
                 tag, cmd, *args = shlex.split(line)
                 self.seq_id = tag
             except ValueError:
-                self.logger.debug(f"(imap) Unknown command: {line!r}")
+                self.logger.debug(f"Unknown command: {line!r}")
                 self.bad("Invalid command")
                 continue
 
@@ -231,7 +231,7 @@ class IMAPHandler(BaseProtoHandler):
                 except StopHandler:
                     break
             else:
-                self.logger.debug(f"(imap) Unknown command: {line!r}")
+                self.logger.debug(f"Unknown command: {line!r}")
                 #  7.1.5. BYE Response
                 self._push("BYE Unknown command", seq=False)
                 break
@@ -240,7 +240,7 @@ class IMAPHandler(BaseProtoHandler):
         data = self.rfile.readline(size)
         if data:
             text = data.decode("utf-8", errors="replace").strip()
-            self.logger.debug(f"(imap) C: {text!r}")
+            self.logger.debug(repr(text), is_client=True)
             return text
 
     # implementation

--- a/dementor/protocols/ntlm.py
+++ b/dementor/protocols/ntlm.py
@@ -147,7 +147,7 @@ def NTLM_new_timestamp() -> int:
 
 
 def NTLM_split_fqdn(fqdn: str):
-    return fqdn.split(".", 1) if "." in fqdn else (fqdn, "")
+    return fqdn.split(".", 1) if "." in fqdn else (fqdn, "WORKGROUP")
 
 
 def NTLM_AUTH_is_anonymous(token: ntlm.NTLMAuthChallengeResponse) -> bool:

--- a/dementor/protocols/ntlm.py
+++ b/dementor/protocols/ntlm.py
@@ -33,7 +33,8 @@ from dementor.config.util import is_true, get_value, BytesValue
 ATTR_NTLM_CHALLENGE = Attribute(
     "ntlm_challenge",
     "NTLM.Challenge",
-    b"1337LEET",
+    # Documentation states that a random challenge will be used
+    default_val=None,
     section_local=False,
     factory=BytesValue(8),
 )

--- a/dementor/protocols/ntlm.py
+++ b/dementor/protocols/ntlm.py
@@ -27,25 +27,7 @@ from impacket import ntlm
 
 from dementor.config.toml import Attribute
 from dementor.config.session import SessionConfig
-from dementor.config.util import is_true, get_value
-
-
-def ntlm_config_get_challenge(value: str | bytes | None) -> bytes:
-    match value:
-        case None:
-            return secrets.token_bytes(8)
-
-        case str():
-            try:
-                return bytes.fromhex(value)
-            except ValueError:
-                return value.encode()
-
-        case bytes():
-            return value
-
-        case _:
-            return str(value).encode()
+from dementor.config.util import is_true, get_value, BytesValue
 
 
 ATTR_NTLM_CHALLENGE = Attribute(
@@ -53,7 +35,7 @@ ATTR_NTLM_CHALLENGE = Attribute(
     "NTLM.Challenge",
     b"1337LEET",
     section_local=False,
-    factory=ntlm_config_get_challenge,
+    factory=BytesValue(8),
 )
 
 ATTR_NTLM_ESS = Attribute(

--- a/dementor/protocols/pop3.py
+++ b/dementor/protocols/pop3.py
@@ -124,7 +124,7 @@ class POP3Handler(BaseProtoHandler):
         line = str(msg)
         if prefix:
             line = f"{prefix} {line}"
-        self.logger.debug(f"(pop3) S: {line!r}")
+        self.logger.debug(repr(line), is_server=True)
         self.send(f"{line}\r\n".encode("utf-8", "strict"))
 
     def challenge_auth(
@@ -139,7 +139,7 @@ class POP3Handler(BaseProtoHandler):
 
         self.line(line)
         resp = self.rfile.readline(1024).strip().decode("utf-8", errors="replace")
-        self.logger.debug(f"(pop3) C: {resp!r}")
+        self.logger.debug(repr(resp), is_client=True)
         # A client response consists of a line containing a string
         # encoded as Base64.  If the client wishes to cancel the
         # authentication exchange, it issues a line with a single "*".
@@ -167,7 +167,7 @@ class POP3Handler(BaseProtoHandler):
         # now identify and authenticate itself to the POP3 server.
         while line := self.rfile.readline(1024):
             line = line.decode("utf-8", errors="replace").strip()
-            self.logger.debug(f"(pop3) C: {line!r}")
+            self.logger.debug(repr(line), is_client=True)
 
             args = line.split(" ")
             if len(args) > 0:
@@ -179,7 +179,7 @@ class POP3Handler(BaseProtoHandler):
                         break
                 continue
 
-            self.logger.debug(f"(pop3) Unknown command: {line!r}")
+            self.logger.debug(f"Unknown command: {line!r}")
             self.err("Unknown command")
 
     # Implementation

--- a/dementor/protocols/smtp.py
+++ b/dementor/protocols/smtp.py
@@ -214,7 +214,6 @@ class SMTPServerHandler:
                 except binascii.Error:
                     self.logger.debug(
                         f"Could not parse input NTLM negotiate: {args[1]}",
-                        host=server.session.peer[0],
                     )
                     await server.push("501 5.7.0 Auth aborted")
                     return MISSING

--- a/dementor/protocols/spnego.py
+++ b/dementor/protocols/spnego.py
@@ -17,19 +17,28 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from impacket.spnego import SPNEGO_NegTokenResp, TypesMech
+from impacket.spnego import SPNEGO_NegTokenResp, TypesMech, SPNEGO_NegTokenInit
+
+
+SPNEGO_NTLMSSP_MECH = "NTLMSSP - Microsoft NTLM Security Support Provider"
 
 
 def negTokenInit_step(
-    negResult: int,
-    respToken: bytes | None = None,
-    supportedMech: str | None = None,
+    neg_result: int,
+    resp_token: bytes | None = None,
+    supported_mech: str | None = None,
 ) -> SPNEGO_NegTokenResp:
     response = SPNEGO_NegTokenResp()
-    response["NegState"] = negResult.to_bytes(1)
-    if supportedMech:
-        response["SupportedMech"] = TypesMech[supportedMech]
-    if respToken:
-        response["ResponseToken"] = respToken
+    response["NegState"] = neg_result.to_bytes(1)
+    if supported_mech:
+        response["SupportedMech"] = TypesMech[supported_mech]
+    if resp_token:
+        response["ResponseToken"] = resp_token
 
     return response
+
+
+def negTokenInit(mech_types: list) -> SPNEGO_NegTokenInit:
+    token_init = SPNEGO_NegTokenInit()
+    token_init["MechTypes"] = [TypesMech[x] for x in mech_types]
+    return token_init

--- a/dementor/servers.py
+++ b/dementor/servers.py
@@ -67,6 +67,9 @@ class ServerThread(threading.Thread):
 
 
 class BaseProtoHandler(BaseRequestHandler, ProtocolLoggerMixin):
+    class TerminateConnection(Exception):
+        pass
+
     def __init__(self, config: SessionConfig, request, client_address, server) -> None:
         self.client_address = client_address
         self.server = server
@@ -87,6 +90,8 @@ class BaseProtoHandler(BaseRequestHandler, ProtocolLoggerMixin):
                 data = None
 
             self.handle_data(data, transport)
+        except BaseProtoHandler.TerminateConnection:
+            pass
         except BrokenPipeError:
             pass  # connection closed, maybe log that
         except TimeoutError:

--- a/docs/source/compat.rst
+++ b/docs/source/compat.rst
@@ -95,11 +95,11 @@ in development. The legend for each symbol is as follows:
                 </table>
             </td>
             <td>
-                <i class="i-lucide check-check sd-text-success l"></i>
+                <i class="i-lucide triangle-alert sd-text-warning l"></i>
                 <table>
                 <tbody>
                     <tr>
-                        <td><i class="i-lucide checkfb sd-text-success l"></i></td>
+                        <td><i class="i-lucide triangle-alert sd-text-warning l"></i></td>
                     </tr>
                     <tr>
                         <td><i class="i-lucide checkfb sd-text-success l"></i></td>
@@ -121,7 +121,7 @@ in development. The legend for each symbol is as follows:
                 <table>
                 <tbody>
                     <tr>
-                        <td><i class="i-lucide x sd-text-danger l"></i></td>
+                        <td><i class="i-lucide cancelled sd-text-secondary l"></td>
                     </tr>
                     <tr>
                         <td><i class="i-lucide checkfb sd-text-success l"></i></td>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "Dementor"
 copyright = "2025-Present, MatrixEditor"
 author = "MatrixEditor"
-release = "1.0.0.dev7"
+release = "1.0.0.dev8"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/config/smb.rst
+++ b/docs/source/config/smb.rst
@@ -32,14 +32,35 @@ Section ``[SMB]``
             This attribute must be defined within a dedicated ``[[SMB.Server]]`` section.
 
 
+    .. py:attribute:: Server.ServerOS
+        :type: str
+
+        *Map to* :attr:`smb.SMBServerConfig.smb_server_os`. *May also be set in* ``[SMB]``
+
+        Defines the operating system for the SMB server. These values are used when crafting responses.
+
     .. py:attribute:: Server.ServerName
-                      Server.ServerOS
                       Server.ServerDomain
         :type: str
 
         *Map to* :attr:`smb.SMBServerConfig.smb_server_XXX`. *May also be set in* ``[SMB]``
 
         Defines identification metadata for the SMB server. These values are used when crafting responses.
+
+        .. versionremoved:: 1.0.0.dev8
+            :code:`ServerName` and :code:`ServerDomain` were merged into :attr:`SMB.Server.FQDN`
+
+    .. py:attribute:: Server.FQDN
+        :type: str
+        :value: "Dementor"
+
+        *Linked to* :attr:`smb.SMBServerConfig.smb_fqdn`. *Can also be set in* ``[SMB]`` *or* ``[Globals]``
+
+        Specifies the Fully Qualified Domain Name (FQDN) hostname used by the SMB server.
+        The hostname portion of the FQDN will be included in server responses. The domain part is optional
+        and will point to ``WORKGROUP`` by default.
+
+        .. versionadded:: 1.0.0.dev8
 
 
     .. py:attribute:: Server.ErrorCode
@@ -125,12 +146,26 @@ Section ``[SMB]``
 
         *Corresponds to* :attr:`SMB.Server.ServerName`
 
+        .. versionremoved:: 1.0.0.dev8
+            Merged into :attr:`SMB.Server.FQDN`
+
 
     .. py:attribute:: smb_server_domain
         :type: str
         :value: "WORKGROUP"
 
         *Corresponds to* :attr:`SMB.Server.ServerDomain`
+
+        .. versionremoved:: 1.0.0.dev8
+            Merged into :attr:`SMB.Server.FQDN`
+
+    .. py:attribute:: smb_fqdn
+        :type: str
+        :value: "DEMENTOR"
+
+        *Corresponds to* :attr:`SMB.Server.FQDN`
+
+        .. versionadded:: 1.0.0.dev8
 
 
     .. py:attribute:: smb_error_code
@@ -174,9 +209,8 @@ Default Configuration
     :caption: SMB configuration section (default values)
 
     [SMB]
-    ServerName = "SPOOFED"
-    ServerOS = "UNIX"
-    ServerDomain = "WORKGROUP"
+    ServerOS = "Windows"
+    FQDN = "DEMENTOR"
     SMB2Support = true
     ErrorCode = "STATUS_SMB_BAD_UID"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dementor"
-version = "1.0.0.dev7"
+version = "1.0.0.dev8"
 license = { file = "LICENSE" }
 
 description = "LLMNR/NBT-NS/mDNS Poisoner and rogue service provider"


### PR DESCRIPTION
This pull request features a complete rewrite of the SMB server dropping the need to use the `SMBSERVER` implemented by impacket. Even though there are no *new* features with the new implementation, the server will support all requested SMB2 dialects. impacket's SMB server only allows 2.0.2.

### Other fixes

+ Updated logging mechanism to always include the current protocol, client host and port
+ Default domain name in FQDN will be `"WORKGROUP"`